### PR TITLE
Feat: running db migrations on app startup

### DIFF
--- a/currency-exchange/.dockerignore
+++ b/currency-exchange/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/currency-exchange/.env.sample
+++ b/currency-exchange/.env.sample
@@ -1,3 +1,6 @@
+# Environment Configuration
+NODE_ENV=development
+
 # Database Configuration
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432

--- a/currency-exchange/Dockerfile
+++ b/currency-exchange/Dockerfile
@@ -13,8 +13,6 @@ RUN npm install
 
 COPY . .
 
-RUN rm typeorm.ts
-
 RUN npm run build
 
 HEALTHCHECK --interval=5s --timeout=3s \

--- a/currency-exchange/docker-compose.yml
+++ b/currency-exchange/docker-compose.yml
@@ -5,12 +5,16 @@ services:
       - '${APP_PORT}:${APP_PORT}'
     env_file:
       - ./.env
+    environment:
+      - NODE_ENV=production
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules
     depends_on:
       postgres:
         condition: service_healthy
+      web-migrations:
+        condition: service_completed_successfully
 
   postgres:
     image: postgres:17.2
@@ -30,6 +34,20 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+
+  web-migrations:
+    build: .
+    command: npm run migration:run
+    env_file:
+      - ./.env
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/currency-exchange/typeorm.ts
+++ b/currency-exchange/typeorm.ts
@@ -12,7 +12,7 @@ export const AppDataSource = new DataSource({
   port: parseInt(configService.get<string>('POSTGRES_PORT')),
   username: configService.get<string>('POSTGRES_USERNAME'),
   password: configService.get<string>('POSTGRES_PASSWORD'),
-  database: configService.get<string>('POSTGRES_DB'),
+  database: configService.get<string>('POSTGRES_DATABASE'),
   entities: [__dirname + '/**/*.entity{.ts,.js}'],
   migrations: ['src/models/migrations/*.ts'],
   synchronize: false,

--- a/currency-exchange/typeorm.ts
+++ b/currency-exchange/typeorm.ts
@@ -5,10 +5,13 @@ import { DataSource } from 'typeorm/data-source/DataSource';
 config(); // Load environment variables from .env file
 const configService = new ConfigService();
 
+const isDevelopment = configService.get<string>('NODE_ENV') === 'development';
+
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  // host: configService.get<string>('POSTGRES_HOST'),
-  host: 'localhost', // left for development purposes
+  host: isDevelopment
+    ? 'localhost'
+    : configService.get<string>('POSTGRES_HOST'),
   port: parseInt(configService.get<string>('POSTGRES_PORT')),
   username: configService.get<string>('POSTGRES_USERNAME'),
   password: configService.get<string>('POSTGRES_PASSWORD'),


### PR DESCRIPTION
- add `web-migrations` container to the docker-compose and run it before the main container
- add `dockerignore`
- resolve db host based on the app env